### PR TITLE
Improve README and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yuu6798
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,110 @@
 # PoR ΔE Library
 
-This repository provides a reference implementation of the PoR trigger and ΔE scoring models from **UGHer** theory. It is intended for researchers and developers who want a simple, open source base for experimenting with Proof‑of‑Reserves (PoR) calculations.
+A lightweight Python library that demonstrates Proof-of-Reserves (PoR) trigger computation and ΔE (delta E) energy scoring. The project offers straightforward functions for experimentation with reserve verification models.
 
 ## Features
 
-- **`por_trigger`** – Calculate whether a PoR check should be triggered based on reserve and distortion parameters.
-- **`deltae_score`** – Compute the energy difference ΔE between two values.
+- **PoR trigger calculation** via `por_trigger`
+- **ΔE scoring** with `deltae_score`
+- Minimal dependencies and easy to integrate
+- Python 3.8+ compatible
+
+## Requirements
+
+- Python 3.8 or higher
 
 ## Installation
 
-Clone this repository or install directly via `pip`:
+Install directly from GitHub using `pip`:
 
 ```bash
 pip install git+https://github.com/Yuu6798/por-deltae-lib.git
 ```
 
-Python 3.8 or higher is recommended.
+Alternatively, clone the repository:
 
-## Usage
+```bash
+git clone https://github.com/Yuu6798/por-deltae-lib.git
+```
+
+## Quick Start
 
 ```python
 from por_trigger import por_trigger
 from deltae_scoring import deltae_score
 
-# Determine if a PoR event should trigger
-res = por_trigger(q=1.0, s=0.9, t=1.2, phi_C=1.05, D=0.1)
-print(res["triggered"], res)
+# Quick PoR check
+result = por_trigger(q=1.0, s=0.9, t=1.2, phi_C=1.05, D=0.1)
+print(result)
 
-# Calculate ΔE between two energy values
+# Simple ΔE calculation
 print(deltae_score(E1=10.0, E2=12.5))
 ```
 
+## Usage
+
+The `por_trigger` function returns a dictionary with the intermediate score and a boolean indicating whether the PoR threshold was exceeded. `deltae_score` simply returns the difference between two energy values.
+
+```python
+from por_trigger import por_trigger
+from deltae_scoring import deltae_score
+
+metrics = por_trigger(q=0.8, s=0.95, t=1.1, phi_C=1.02, D=0.05, theta=0.6)
+if metrics["triggered"]:
+    print("PoR event triggered!", metrics)
+
+energy_gap = deltae_score(E1=8.0, E2=9.5)
+print("ΔE:", energy_gap)
+```
+
+## API Reference
+
+### `por_trigger(q: float, s: float, t: float, phi_C: float, D: float, *, theta: float = 0.6) -> dict`
+
+Calculates whether a PoR event should be triggered.
+
+**Parameters**
+- `q` – quantity factor for reserves
+- `s` – sensitivity factor
+- `t` – time factor
+- `phi_C` – scoring coefficient
+- `D` – distortion factor
+- `theta` – trigger threshold (default `0.6`)
+
+**Returns**
+A dictionary containing:
+- `"E_prime"` – intermediate energy metric
+- `"score"` – calculated score
+- `"triggered"` – `True` if the threshold is exceeded
+
+### `deltae_score(E1: float, E2: float) -> float`
+
+Computes `E2 - E1`.
+
+**Parameters**
+- `E1` – first energy value
+- `E2` – second energy value
+
+**Returns**
+- The difference `E2 - E1`
+
 ## Project Structure
 
-- `por_trigger.py` – implementation of the PoR trigger calculation.
-- `deltae_scoring.py` – implementation of the ΔE scoring helper.
+- `por_trigger.py` – PoR trigger implementation
+- `deltae_scoring.py` – ΔE scoring helper
+- `design_sketch.py` – simplified reference code
+- `spec.md` – specification outline (currently empty)
+- `pyproject.toml` – packaging metadata
 
 ## Contributing
 
-Contributions are welcome. Feel free to open issues or submit pull requests.
+Contributions are welcome! Feel free to open issues or submit pull requests.
 
 ## Contact
 
-For questions or suggestions, please contact [Yuu6798](https://github.com/Yuu6798).
+Questions or suggestions? Reach out to [Yuu6798](https://github.com/Yuu6798).
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for details.
+


### PR DESCRIPTION
## Summary
- document project features and usage examples in README
- add an MIT License file

## Testing
- `python -m py_compile por_trigger.py deltae_scoring.py design_sketch.py`